### PR TITLE
Fix build with Clang > 3.5

### DIFF
--- a/src/libSystem/libc/OSAtomic.cpp
+++ b/src/libSystem/libc/OSAtomic.cpp
@@ -239,7 +239,7 @@ void* OSAtomicDequeue(OSQueueHead *list, size_t offset)
 	return nullptr;
 }
 
-__attribute__((naked)) void OSMemoryBarrier()
+void OSMemoryBarrier()
 {
 	__atomic_thread_fence(__ATOMIC_SEQ_CST);
 }


### PR DESCRIPTION
Inspired of 91dcde2c301d1093b89937188f604dd79d96609b
I can build Darling with Clang 3.6 with this.